### PR TITLE
Added event handler

### DIFF
--- a/Assets/Scripts/Enums.meta
+++ b/Assets/Scripts/Enums.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ef95977ac4794348be0cb37f52c805e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enums/Enums.cs
+++ b/Assets/Scripts/Enums/Enums.cs
@@ -1,0 +1,5 @@
+﻿public enum ToolEffect
+{
+    none,
+    watering
+}

--- a/Assets/Scripts/Enums/Enums.cs.meta
+++ b/Assets/Scripts/Enums/Enums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cdd6cb6cc730b549bcd9a6cee98fe99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Events.meta
+++ b/Assets/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 503d1abd3aab11c4bb45bb9e6b4b2246
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Events/EventHandler.cs
+++ b/Assets/Scripts/Events/EventHandler.cs
@@ -1,0 +1,35 @@
+﻿public delegate void MovementDelegate(float inputX, float inputY, bool isWalking, bool isRunning, bool isIdle, bool isCarrying,
+    ToolEffect tooleffect,
+      bool isUsingToolRight, bool isUsingToolLeft, bool isUsingToolUp, bool isUsingToolDown,
+      bool isLiftingToolRight, bool isLiftingToolLeft, bool isLiftingToolUp, bool isLiftingToolDown,
+      bool isPickingRight, bool isPickingLeft, bool isPickingUp, bool isPickingDown,
+      bool isSwingingToolRight, bool isSwingingToolLeft, bool isSwingingToolUp, bool isSwingingToolDown,
+      bool idleUp, bool idleDown, bool idleLeft, bool idleRight);
+
+public static class EventHandler
+{
+    // Movement Event
+
+    public static event MovementDelegate MovementEvent;
+
+    // Movement Event Call for Publishera
+
+    public static void CallMovementEvent(float inputX, float inputY, bool isWalking, bool isRunning, bool isIdle, bool isCarrying,
+    ToolEffect tooleffect,
+      bool isUsingToolRight, bool isUsingToolLeft, bool isUsingToolUp, bool isUsingToolDown,
+      bool isLiftingToolRight, bool isLiftingToolLeft, bool isLiftingToolUp, bool isLiftingToolDown,
+      bool isPickingRight, bool isPickingLeft, bool isPickingUp, bool isPickingDown,
+      bool isSwingingToolRight, bool isSwingingToolLeft, bool isSwingingToolUp, bool isSwingingToolDown,
+      bool idleUp, bool idleDown, bool idleLeft, bool idleRight)
+    {
+        if (MovementEvent != null)
+            MovementEvent(inputX, inputY,  
+                isWalking, isRunning, isIdle, isCarrying,
+                tooleffect,
+                isUsingToolRight, isUsingToolLeft, isUsingToolUp, isUsingToolDown,
+                isLiftingToolRight, isLiftingToolLeft, isLiftingToolUp, isLiftingToolDown,
+                isPickingRight, isPickingLeft, isPickingUp, isPickingDown,
+                isSwingingToolRight, isSwingingToolLeft, isSwingingToolUp, isSwingingToolDown,
+                idleUp, idleDown, idleLeft, idleRight);
+    }
+}

--- a/Assets/Scripts/Events/EventHandler.cs.meta
+++ b/Assets/Scripts/Events/EventHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 772bcd49c15d0b540b924a1e5436c349
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Implemented an event handler using a Publisher>Event>Subscriber design pattern 
Using this method the Player acts as the publisher; issuing commands that will cause events. These events are then handled, in this case by animating the sprites, by the Subscriber.
C# handles events using the **_delegate & event_** functions

Example:

`public delegate void MovementDelegate(int p1, int p2)
public static event MovementDelegateMovementEvent`